### PR TITLE
Use unions to reduce the memory used

### DIFF
--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 DEBUG=0
 
-CFLAGS="-W -Wall -Werror -std=c99 -pedantic"
+CFLAGS="-W -Wall -Werror -std=c11 -pedantic"
 
 if [ $# -eq 1 ]; then
 	if [ -z "${1##*"S"*}" ]; then

--- a/src/storage.c
+++ b/src/storage.c
@@ -156,8 +156,14 @@ JSON *init_json(char is_array, Array *a, Dict *d)
         return 0;
     }
     j->is_array = is_array;
-    j->array = a;
-    j->dict = d;
+    if (is_array)
+    {
+        j->array = a;
+    }
+    else
+    {
+        j->dict = d;
+    }
     return j;
 }
 
@@ -567,6 +573,11 @@ Item dict_get(Dict *d, String key)
 *******************************************************************************/
 void destroy_array(Array *a)
 {
+    if (!a)
+    {
+        return;
+    }
+
     free(a->indexes_types);
 
     StrArrLink *sl = a->strings_head;
@@ -633,8 +644,13 @@ void destroy_array(Array *a)
 
 void destroy_dict(Dict *d)
 {
+    if (!d)
+    {
+        return;
+    }
+
     // The keys that are pointed to by the elements of this array will be freed
-    // when freeing the element, so we don't do it here
+    // when freeing the elements, so we don't do it here
     free(d->keys_types);
 
     StrDictLink *sl = d->strings_head;
@@ -713,12 +729,11 @@ void destroy_json(JSON *j)
         return;
     }
 
-    if (j->array)
+    if (j->is_array)
     {
         destroy_array(j->array);
     }
-
-    if (j->dict)
+    else
     {
         destroy_dict(j->dict);
     }

--- a/src/storage.h
+++ b/src/storage.h
@@ -175,6 +175,13 @@ struct dict_dict_link
     struct dict_dict_link *next;
 };
 
+struct generic_dict_link
+{
+    String key;
+    Dict *value;
+    struct dict_dict_link *next;
+};
+
 typedef struct str_dict_link StrDictLink;
 typedef struct int_dict_link IntDictLink;
 typedef struct double_dict_link DoubleDictLink;
@@ -239,8 +246,11 @@ struct dict_linked_list
 typedef struct
 {
     char is_array;
-    Array *array;
-    Dict *dict;
+    union
+    {
+        Array *array;
+        Dict *dict;
+    };
 } JSON;
 
 /*******************************************************************************

--- a/src/storage.h
+++ b/src/storage.h
@@ -87,12 +87,15 @@ typedef struct dict_array_link DictArrLink;
 typedef struct
 {
     char type;
-    String strv;
-    int intv;
-    double doublev;
-    char boolv;
-    Array *arrayv;
-    Dict *dictv;
+    union
+    {
+        String strv;
+        int intv;
+        double doublev;
+        char boolv;
+        Array *arrayv;
+        Dict *dictv;
+    };
 } Value;
 
 // Linked list for arrays
@@ -185,12 +188,15 @@ typedef struct
 {
     char type;
     String key;
-    String strv;
-    int intv;
-    double doublev;
-    char boolv;
-    Array *arrayv;
-    Dict *dictv;
+    union
+    {
+        String strv;
+        int intv;
+        double doublev;
+        char boolv;
+        Array *arrayv;
+        Dict *dictv;
+    };
 } Item;
 
 typedef struct


### PR DESCRIPTION
Before the use of unions, the structures sizes were as follows :

- Value : 64
- Item : 80
- JSON : 24

With unions :

- Value : 24
- Item : 40
- JSON : 16

It should also be noted that from now on, `c11` will be used as `c99` doesn't support anonymous unions